### PR TITLE
Plugin isn't up to spec for new plugin system.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,5 @@
 name: "ConfigTag"
+slug: "config-tag"
 author: "Brandon Mathis"
 description: "ConfigTag reads a Jekyll config and writes an HTML tag with its values as HTML5 data attributes"
 url: "https://github.com/octopress/config-tag"


### PR DESCRIPTION
Non-theme plugins need a slug value.
